### PR TITLE
[feat] 맛집 평가 생성 구현

### DIFF
--- a/src/main/java/wanted/ribbon/store/controller/ReviewController.java
+++ b/src/main/java/wanted/ribbon/store/controller/ReviewController.java
@@ -1,0 +1,22 @@
+package wanted.ribbon.store.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import wanted.ribbon.store.dto.CreateReviewRequestDto;
+import wanted.ribbon.store.dto.CreateReviewResponseDto;
+import wanted.ribbon.store.service.ReviewService;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @PostMapping("/{storeId}")
+    public ResponseEntity<CreateReviewResponseDto> createReview(@PathVariable Long storeId, @RequestBody CreateReviewRequestDto requestDto) {
+        CreateReviewResponseDto responseDto = reviewService.createReview(storeId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/wanted/ribbon/store/domain/Store.java
+++ b/src/main/java/wanted/ribbon/store/domain/Store.java
@@ -40,4 +40,8 @@ public class Store {
 
     @Column(nullable = false, columnDefinition = "double default 0")
     private double rating;
+
+    public void updateRating(double rating) {
+        this.rating = rating;
+    }
 }

--- a/src/main/java/wanted/ribbon/store/dto/CreateReviewRequestDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/CreateReviewRequestDto.java
@@ -1,0 +1,4 @@
+package wanted.ribbon.store.dto;
+
+public record CreateReviewRequestDto(int score, String content) {
+}

--- a/src/main/java/wanted/ribbon/store/dto/CreateReviewResponseDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/CreateReviewResponseDto.java
@@ -1,0 +1,4 @@
+package wanted.ribbon.store.dto;
+
+public record CreateReviewResponseDto(int score, String content) {
+}

--- a/src/main/java/wanted/ribbon/store/service/ReviewService.java
+++ b/src/main/java/wanted/ribbon/store/service/ReviewService.java
@@ -1,0 +1,50 @@
+package wanted.ribbon.store.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wanted.ribbon.exception.ErrorCode;
+import wanted.ribbon.exception.NotFoundException;
+import wanted.ribbon.store.domain.Review;
+import wanted.ribbon.store.domain.Store;
+import wanted.ribbon.store.dto.CreateReviewRequestDto;
+import wanted.ribbon.store.dto.CreateReviewResponseDto;
+import wanted.ribbon.store.repository.ReviewRepository;
+import wanted.ribbon.store.repository.StoreRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public CreateReviewResponseDto createReview(Long storeId, CreateReviewRequestDto requestDto) {
+        Store store = storeRepository.findByStoreId(storeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND));
+        Review review = Review.builder()
+                .score(requestDto.score())
+                .content(requestDto.content())
+                .store(store)
+                .build();
+        reviewRepository.save(review);
+
+        updateRating(store);
+
+        CreateReviewResponseDto responseDto = new CreateReviewResponseDto(requestDto.score(), requestDto.content());
+        return responseDto;
+    }
+
+    public void updateRating(Store store) {
+        List<Review> reviewList = reviewRepository.findByStore_StoreId(store.getStoreId());
+
+        double rating = reviewList.stream()
+                .mapToDouble(Review::getScore)
+                .average()
+                .orElse(0.0);
+
+        store.updateRating(rating);
+    }
+}


### PR DESCRIPTION
- User와 Review 엔티티가 연결되지 않은 상태에서 api 생성 (차후 수정)

## Issue
- #14 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/review -> feat/store

## 변경 사항
- 맛집 평가 생성
- 맛집 리뷰 점수 등록 시 해당 맛집의 평점 업데이트

## 테스트 결과

### Request
```java
HTTP : POST
URL: /api/reviews/:storeId
```
- body
```
{
  "score": 점수,
  "content": 내용
}
```

### Response : 성공시
`201 Created`
```
{
  "score": 점수,
  "content": 내용
}
```

### Response : 실패시
- 잘못된 `storeId`를 입력했을 때
```
{
    "status": 404,
    "message": "존재하지 않는 맛집입니다."
}
```