### PR TITLE
[refactor] 맛집 상세정보, 맛집 평가 생성 API 수정

### DIFF
--- a/src/main/java/wanted/ribbon/store/controller/ReviewController.java
+++ b/src/main/java/wanted/ribbon/store/controller/ReviewController.java
@@ -7,16 +7,22 @@ import org.springframework.web.bind.annotation.*;
 import wanted.ribbon.store.dto.CreateReviewRequestDto;
 import wanted.ribbon.store.dto.CreateReviewResponseDto;
 import wanted.ribbon.store.service.ReviewService;
+import wanted.ribbon.user.config.TokenProvider;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
 public class ReviewController {
     private final ReviewService reviewService;
+    private final TokenProvider tokenProvider;
 
     @PostMapping("/{storeId}")
-    public ResponseEntity<CreateReviewResponseDto> createReview(@PathVariable Long storeId, @RequestBody CreateReviewRequestDto requestDto) {
-        CreateReviewResponseDto responseDto = reviewService.createReview(storeId, requestDto);
+    public ResponseEntity<CreateReviewResponseDto> createReview(@PathVariable Long storeId, @RequestHeader(value = "Authorization")String token, @RequestBody CreateReviewRequestDto requestDto) {
+        String accessToken = token.split("Bearer ")[1];
+        String id = tokenProvider.getId(accessToken); // 액세스토큰으로 id 반환
+        CreateReviewResponseDto responseDto = reviewService.createReview(storeId, id, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 }

--- a/src/main/java/wanted/ribbon/store/domain/Review.java
+++ b/src/main/java/wanted/ribbon/store/domain/Review.java
@@ -2,6 +2,7 @@ package wanted.ribbon.store.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import wanted.ribbon.user.domain.User;
 
 @Entity
 @Getter
@@ -24,4 +25,8 @@ public class Review {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 }

--- a/src/main/java/wanted/ribbon/store/dto/CreateReviewResponseDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/CreateReviewResponseDto.java
@@ -1,4 +1,4 @@
 package wanted.ribbon.store.dto;
 
-public record CreateReviewResponseDto(int score, String content) {
+public record CreateReviewResponseDto(String id, int score, String content) {
 }

--- a/src/main/java/wanted/ribbon/store/dto/ReviewListResponseDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/ReviewListResponseDto.java
@@ -1,4 +1,4 @@
 package wanted.ribbon.store.dto;
 
-public record ReviewListResponseDto(int score, String content) {
+public record ReviewListResponseDto(String id, int score, String content) {
 }

--- a/src/main/java/wanted/ribbon/store/service/ReviewService.java
+++ b/src/main/java/wanted/ribbon/store/service/ReviewService.java
@@ -11,29 +11,38 @@ import wanted.ribbon.store.dto.CreateReviewRequestDto;
 import wanted.ribbon.store.dto.CreateReviewResponseDto;
 import wanted.ribbon.store.repository.ReviewRepository;
 import wanted.ribbon.store.repository.StoreRepository;
+import wanted.ribbon.user.domain.User;
+import wanted.ribbon.user.repository.UserRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
 
     @Transactional
-    public CreateReviewResponseDto createReview(Long storeId, CreateReviewRequestDto requestDto) {
+    public CreateReviewResponseDto createReview(Long storeId, String id, CreateReviewRequestDto requestDto) {
         Store store = storeRepository.findByStoreId(storeId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND));
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
         Review review = Review.builder()
                 .score(requestDto.score())
                 .content(requestDto.content())
                 .store(store)
+                .user(user)
                 .build();
         reviewRepository.save(review);
 
+        // 점수 입력되면 해당 맛집의 평점 update
         updateRating(store);
 
-        CreateReviewResponseDto responseDto = new CreateReviewResponseDto(requestDto.score(), requestDto.content());
+        CreateReviewResponseDto responseDto = new CreateReviewResponseDto(id, requestDto.score(), requestDto.content());
         return responseDto;
     }
 

--- a/src/main/java/wanted/ribbon/store/service/StoreService.java
+++ b/src/main/java/wanted/ribbon/store/service/StoreService.java
@@ -26,7 +26,7 @@ public class StoreService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.STORE_NOT_FOUND));
         List<Review> reviewList = reviewRepository.findByStore_StoreId(storeId);
         List<ReviewListResponseDto> reviewListResponseDto = reviewList.stream()
-                .map(list -> new ReviewListResponseDto(list.getScore(), list.getContent()))
+                .map(list -> new ReviewListResponseDto(list.getUser().getId(), list.getScore(), list.getContent()))
                 .collect(Collectors.toList());
 
         StoreDetailResponseDto responseDto = new StoreDetailResponseDto(

--- a/src/main/java/wanted/ribbon/user/config/TokenProvider.java
+++ b/src/main/java/wanted/ribbon/user/config/TokenProvider.java
@@ -60,10 +60,10 @@ public class TokenProvider {
         return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
     }
 
-    // 토큰 기반으로 유저 ID를 가져오는 메서드
-    public UUID getUserId(String token){
+    // 토큰 기반으로 회원의 ID를 가져오는 메서드
+    public String getId(String token){
         Claims claims = getClaims(token);
-        return claims.get("userId", UUID.class);
+        return claims.getSubject();
     }
 
     private Claims getClaims(String token){

--- a/src/main/java/wanted/ribbon/user/config/WebSecurityConfig.java
+++ b/src/main/java/wanted/ribbon/user/config/WebSecurityConfig.java
@@ -25,7 +25,7 @@ public class WebSecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeRequests(auth -> auth
-                        .requestMatchers("/api/user/login", "/api/user/signup").permitAll()
+                        .requestMatchers("/api/users/login", "/api/users/signup").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## Issue
- #19 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
refactor/store_review -> feat/store

## 변경 사항
- 맛집 상세 정보 조회 시 평가 상세 리스트에 평가 작성한 회원 id 필드 추가
- 맛집 평가 생성 API에 회원 엔티티 연결 추가

## 테스트 결과

### 1. 맛집 상세 정보
### Request
```java
HTTP : GET
URL: /api/stores/:storeId
```
- Request Header
```
Authorization: “Bearer XXXXXXXXX”
```

### Response : 성공시
```
{
    "storeId": 맛집 일련번호,
    "sigun": 시군명,
    "storeName": 사업장명,
    "category": 위생업태명(분류),
    "address": 소재지도로명주소,
    "storeLat": 위도,
    "storeLon": 경도,
    "rating": 평점,
    "reviewList": [
        {
            "id": 계정명,
            "score": 평가 점수,
            "content": 평가 내용
        },
        ...
    ]
}
```

### Response : 실패시
- 잘못된 `storeId`를 입력했을 때
```
{
    "status": 404,
    "message": "존재하지 않는 맛집입니다."
}
```

### 2. 맛집 평가 생성
### Request
```java
HTTP : POST
URL: /api/reviews/:storeId
```
- Request Header
```
Authorization: “Bearer XXXXXXXXX”
```
- Request body
```
{
  "score": 점수,
  "content": 내용
}
```

### Response : 성공시
`201 Created`
```
{
  "id": 계정명,
  "score": 점수,
  "content": 내용
}
```

### Response : 실패시
- 잘못된 `storeId`를 입력했을 때
```
{
    "status": 404,
    "message": "존재하지 않는 맛집입니다."
}
```