### PR TITLE
[feat] 데이터 자동화 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'io.jsonwebtoken:jjwt:0.9.1' // 자바 JWT 라이브러리
-	  implementation 'javax.xml.bind:jaxb-api:2.3.1' // XML 문서와 Java 객체 간 매핑 자동화
+    implementation 'javax.xml.bind:jaxb-api:2.3.1' // XML 문서와 Java 객체 간 매핑 자동화
     // Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     // Spring Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     // spring-batch-core 최신버전 추가
     implementation 'org.springframework.batch:spring-batch-core:5.1.0'
+    // Quartz
+    implementation 'org.springframework.boot:spring-boot-starter-quartz:3.2.3'
     // QueryDSL - 4개
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     // spring-batch-core 최신버전 추가
     implementation 'org.springframework.batch:spring-batch-core:5.1.0'
-    // Quartz
-    implementation 'org.springframework.boot:spring-boot-starter-quartz:3.2.3'
     // QueryDSL - 4개
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/wanted/ribbon/genrestrt/component/DataFetchTasklet.java
+++ b/src/main/java/wanted/ribbon/genrestrt/component/DataFetchTasklet.java
@@ -1,0 +1,162 @@
+package wanted.ribbon.genrestrt.component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import wanted.ribbon.exception.BaseException;
+import wanted.ribbon.exception.ErrorCode;
+import wanted.ribbon.genrestrt.dto.RawData;
+import wanted.ribbon.genrestrt.mapper.RawDataRowMapper;
+import wanted.ribbon.genrestrt.mapper.StoreDataRowMapper;
+import wanted.ribbon.genrestrt.service.DataProcessor;
+import wanted.ribbon.store.domain.Store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class DataFetchTasklet implements Tasklet {
+    private final JdbcTemplate jdbcTemplate;
+    private final DataProcessor dataProcessor;
+
+    private static final int PAGE_SIZE = 1000;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        int offset = 0;
+        int totalRowsFetched = 0;
+        int totalRowsDeleted = 0;
+
+        List<RawData> rawDataList;
+
+        do {
+            // genrestrts 테이블에서 처리된 데이터를 페이지 단위로 조회
+            String autoSql = "SELECT sigun_nm, bizplc_nm, bsn_state_nm, sanittn_bizcond_nm,refine_roadnm_addr,refine_wgs84lat,refine_wgs84logt " +
+                    "FROM genrestrts " +
+                    "WHERE processed = true " +
+                    "LIMIT ? OFFSET ?";
+
+            // JdbcTemplate를 사용해 데이터 조회
+            rawDataList = jdbcTemplate.query(autoSql,
+                    new Object[]{PAGE_SIZE,offset},
+                    (rs, rowNum) -> new RawDataRowMapper().mapRow(rs, rowNum)
+            );
+            // 조회된 데이터가 없으면 반복 종료
+            if (rawDataList.isEmpty()) {
+                break;
+            }
+
+            for (RawData rawData : rawDataList) {
+              try{
+                  // 1. 영업 상태가 페업으로 변한 경우
+                  if ("폐업".equals(rawData.getBsnStateNm())){
+                      // stores에서 데이터 삭제
+                      String deleteSql = "DELETE FROM stores " +
+                              "WHERE store_name = ? AND address = ?";
+                      int rowsDeleted = jdbcTemplate.update(deleteSql,rawData.getBizplcNm(),rawData.getRefineRoadnmAddr());
+
+                      // 로그에 삭제된 맛집 정보 알림
+                      if (rowsDeleted > 0) {
+                          log.info("삭제된 맛집: 이름={}, 주소={}", rawData.getBizplcNm(), rawData.getRefineRoadnmAddr());
+                      }
+
+                      // genrestrts에서 processed 필드 false로 업데이트
+                      String updateGenrestrtsSql = "UPDATE genrestrts SET processed = false " +
+                              "WHERE bizplc_nm = ? AND refine_roadnm_addr = ?";
+                      jdbcTemplate.update(updateGenrestrtsSql,rawData.getBizplcNm(),rawData.getRefineRoadnmAddr());
+
+                      // 삭제된 행수 업데이트
+                      totalRowsDeleted += rowsDeleted;
+                      continue;
+                  }
+                  // 2. 영업 상태가 폐업이 아닌 경우
+                  Store store = dataProcessor.process(rawData);
+
+                  // stores에서 RawData와 매핑된 레코드 조회
+                  String storeQuery = "SELECT sigun, store_name, category, address, store_lat, store_lon,rating " +
+                          "FROM stores " +
+                          "WHERE store_name = ? AND address = ?";
+                  List<Store> storeDataList = jdbcTemplate.query(storeQuery,
+                          new Object[]{rawData.getBizplcNm(),rawData.getRefineRoadnmAddr()},
+                          new StoreDataRowMapper());
+
+                  // db에서 받아온 Store 데이터와 새롭게 받아온 RawData 비교
+                  if(!storeDataList.isEmpty()) {
+                      Store existingStore = storeDataList.get(0);
+                      // 업데이트 필요 필드 추적
+                      List<Object> updateParams = new ArrayList<>();
+                      StringBuilder updateSql = new StringBuilder("UPDATE stores SET ");
+
+                      // 데이터 비교
+                      if (!existingStore.getSigun().equals(store.getSigun())) {
+                          updateSql.append("sigun = ?, ");
+                          updateParams.add(store.getSigun());
+                      }
+                      if (!existingStore.getStoreName().equals(store.getStoreName())) {
+                          updateSql.append("store_name = ?, ");
+                          updateParams.add(store.getStoreName());
+                      }
+                      if (!existingStore.getCategory().equals(store.getCategory())) {
+                          updateSql.append("category = ?, ");
+                          updateParams.add(store.getCategory());
+                      }
+                      if (!existingStore.getAddress().equals(store.getAddress())) {
+                          updateSql.append("address = ?, ");
+                          updateParams.add(store.getAddress());
+                      }
+                      /*
+                      * Double 값의 경우 일치 여부 확인
+                      * 1. Math.abs를 이용하여 두 값의 차이를 비교
+                      * 2. EPSILON (허용 오차범위) 설정
+                      * */
+                      // EPSILON (허용 오차범위) 설정
+                      final double EPSILON = 0.00001;
+                      if ((Math.abs(existingStore.getStoreLat()-store.getStoreLat()) > EPSILON) ||
+                              (Math.abs(store.getStoreLat()-existingStore.getStoreLat()) > EPSILON)) {
+                          updateSql.append("store_lat = ?, ");
+                          updateParams.add(store.getStoreLat());
+                      }
+                      if ((Math.abs(existingStore.getStoreLon()-store.getStoreLon()) > EPSILON) ||
+                              (Math.abs(store.getStoreLon()-existingStore.getStoreLon()) > EPSILON)){
+                          updateSql.append("store_lon = ?, ");
+                          updateParams.add(store.getStoreLon());
+                      }
+
+                      // 변경된 필드가 있는 경우에만 업데이트 실행
+                      if (!updateParams.isEmpty()) {
+                          updateSql.setLength(updateSql.length()-2); // 마지막 필드 뒤의 쉼표 제거
+                          updateSql.append("WHERE store_name = ? AND address = ?");
+                          updateParams.add(rawData.getBizplcNm());
+                          updateParams.add(rawData.getRefineRoadnmAddr());
+
+                          int rowsFetched = jdbcTemplate.update(updateSql.toString(),updateParams.toArray());
+
+                          if (rowsFetched > 0) {
+                              log.info("변경된 맛집: 이름={}, 주소={}", rawData.getBizplcNm(), rawData.getRefineRoadnmAddr());
+                          }
+                          totalRowsFetched += rowsFetched; // 총 변경 처리된 데이터 수 누적
+                      }
+                  }
+              } catch (Exception e) {
+                  throw new BaseException(ErrorCode.DATA_PIPE_TASKLET_ERROR,e.getMessage());
+              }
+            }
+            offset += PAGE_SIZE; // 다음 페이지로 이동하기 위해 오프셋 증가
+        } while (!rawDataList.isEmpty());
+
+        // 최종 보고 로그
+        log.info("정보가 바뀐 맛집의 수는: {}", totalRowsFetched);
+        log.info("정보가 지워진 맛집의 수는: {}", totalRowsDeleted);
+
+        return RepeatStatus.FINISHED; // 배치 작업 완료 상태 반환
+    }
+}

--- a/src/main/java/wanted/ribbon/genrestrt/component/DataFetchTasklet.java
+++ b/src/main/java/wanted/ribbon/genrestrt/component/DataFetchTasklet.java
@@ -109,28 +109,19 @@ public class DataFetchTasklet implements Tasklet {
                           updateSql.append("category = ?, ");
                           updateParams.add(store.getCategory());
                       }
+                      /*
+                       * 1. 도로명 주소가 변경된 경우
+                       * 2. 위도, 경도 함께 변경된 경우가 많지 않을까?
+                       * 3. 도로명주소, 위도, 경도 같이 업데이트
+                       */
                       if (!existingStore.getAddress().equals(store.getAddress())) {
                           updateSql.append("address = ?, ");
                           updateParams.add(store.getAddress());
-                      }
-                      /*
-                      * Double 값의 경우 일치 여부 확인
-                      * 1. Math.abs를 이용하여 두 값의 차이를 비교
-                      * 2. EPSILON (허용 오차범위) 설정
-                      * */
-                      // EPSILON (허용 오차범위) 설정
-                      final double EPSILON = 0.00001;
-                      if ((Math.abs(existingStore.getStoreLat()-store.getStoreLat()) > EPSILON) ||
-                              (Math.abs(store.getStoreLat()-existingStore.getStoreLat()) > EPSILON)) {
-                          updateSql.append("store_lat = ?, ");
+                          updateSql.append("store_lat = ?, "); // 맛집 위도
                           updateParams.add(store.getStoreLat());
-                      }
-                      if ((Math.abs(existingStore.getStoreLon()-store.getStoreLon()) > EPSILON) ||
-                              (Math.abs(store.getStoreLon()-existingStore.getStoreLon()) > EPSILON)){
-                          updateSql.append("store_lon = ?, ");
+                          updateSql.append("store_lon = ?, "); // 맛집 경도
                           updateParams.add(store.getStoreLon());
                       }
-
                       // 변경된 필드가 있는 경우에만 업데이트 실행
                       if (!updateParams.isEmpty()) {
                           updateSql.setLength(updateSql.length()-2); // 마지막 필드 뒤의 쉼표 제거
@@ -141,7 +132,7 @@ public class DataFetchTasklet implements Tasklet {
                           int rowsFetched = jdbcTemplate.update(updateSql.toString(),updateParams.toArray());
 
                           if (rowsFetched > 0) {
-                              log.info("변경된 맛집: 이름={}, 주소={}", rawData.getBizplcNm(), rawData.getRefineRoadnmAddr());
+                              log.info("변경된 맛집: 이름={}, 도로명 주소={}", rawData.getBizplcNm(), rawData.getRefineRoadnmAddr());
                           }
                           totalRowsFetched += rowsFetched; // 총 변경 처리된 데이터 수 누적
                       }

--- a/src/main/java/wanted/ribbon/genrestrt/component/DataPipeJobScheduler.java
+++ b/src/main/java/wanted/ribbon/genrestrt/component/DataPipeJobScheduler.java
@@ -1,0 +1,28 @@
+package wanted.ribbon.genrestrt.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import wanted.ribbon.genrestrt.config.DataPipeJobConfig;
+
+@Component
+@RequiredArgsConstructor
+public class DataPipeJobScheduler {
+    private final JobLauncher jobLauncher;
+    private final DataPipeJobConfig dataPipeJobConfig;
+
+    @Scheduled(cron = "0 0 3 * * 1") // 매주 월요일 새벽 3시 1번 cron 표현식 활용 (초 분 시 일 월 요일)
+    public void DataUpdate() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException, JobRestartException {
+        jobLauncher.run(
+                dataPipeJobConfig.dataPipeJob(),
+                new JobParametersBuilder()
+                        .toJobParameters()
+        );
+    }
+}

--- a/src/main/java/wanted/ribbon/genrestrt/component/DataPipeTasklet.java
+++ b/src/main/java/wanted/ribbon/genrestrt/component/DataPipeTasklet.java
@@ -77,7 +77,7 @@ public class DataPipeTasklet implements Tasklet {
                 jdbcTemplate.update("UPDATE genrestrts SET processed = true WHERE bizplc_nm = ? AND refine_roadnm_addr = ?",
                         rawData.getBizplcNm(), rawData.getRefineRoadnmAddr());
 
-                log.info("데이터 삽입 성공 및 처리 상태 업데이트: {}", store);
+                log.info("데이터 삽입 성공 및 처리 상태 업데이트: {}", store); // 맛집 상세 정보를 받을 것인가?
                 count++; // 처리된 데이터 수 증가
             }
 

--- a/src/main/java/wanted/ribbon/genrestrt/component/DataPipeTasklet.java
+++ b/src/main/java/wanted/ribbon/genrestrt/component/DataPipeTasklet.java
@@ -36,7 +36,7 @@ public class DataPipeTasklet implements Tasklet {
         List<RawData> rawDataList; // 현재 페이지에서 조회된 RawData 리스트
         do {
             // genrestrts 테이블에서 영업 중인 데이터와 처리되지 않은 데이터를 페이지 단위로 조회
-            String sql = "SELECT sigun_nm, bizplc_nm, sanittn_bizcond_nm, refine_roadnm_addr, refine_wgs84lat, refine_wgs84logt " +
+            String sql = "SELECT sigun_nm, bizplc_nm, bsn_state_nm, sanittn_bizcond_nm, refine_roadnm_addr, refine_wgs84lat, refine_wgs84logt " +
                     "FROM genrestrts " +
                     "WHERE bsn_state_nm = '영업' AND processed = false " +
                     "LIMIT ? OFFSET ?";

--- a/src/main/java/wanted/ribbon/genrestrt/config/DataPipeJobConfig.java
+++ b/src/main/java/wanted/ribbon/genrestrt/config/DataPipeJobConfig.java
@@ -4,11 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import wanted.ribbon.genrestrt.component.DataFetchTasklet;
 import wanted.ribbon.genrestrt.component.DataPipeTasklet;
 
 @RequiredArgsConstructor
@@ -16,14 +18,17 @@ import wanted.ribbon.genrestrt.component.DataPipeTasklet;
 public class DataPipeJobConfig {
 
     private final JobRepository jobRepository;
-    private final PlatformTransactionManager transactionManager;
+    private final PlatformTransactionManager transactionManager; // jdbc 사용을 위해
     private final DataPipeTasklet dataPipeTasklet; // Tasklet을 주입받음 -> 모듈화, 세부 관리
+    private final DataFetchTasklet dataFetchTasklet;
 
     // 1. Job 설정 (원본데이터 -> 운영테이블 데이터 저장)
     @Bean
     public Job dataPipeJob() {
         return new JobBuilder("dataPipeJob", jobRepository)
+                .incrementer(new RunIdIncrementer()) // 실행할 때마다 JobParameters에 ID 증가
                 .start(dataPipeStep())
+                .next(dataFetchStep())
                 .build();
     }
 
@@ -32,6 +37,16 @@ public class DataPipeJobConfig {
     public Step dataPipeStep() {
         return new StepBuilder("dataPipeStep", jobRepository)
                 .tasklet(dataPipeTasklet, transactionManager) // Tasklet을 Step에 설정
+                .allowStartIfComplete(true) // 완료된 후에도 재시작 가능
+                .build();
+    }
+
+    // 3. Step2 설정
+    @Bean
+    public Step dataFetchStep() {
+        return new StepBuilder("dataFetchStep",jobRepository)
+                .tasklet(dataFetchTasklet, transactionManager)
+                .allowStartIfComplete(true)
                 .build();
     }
 }

--- a/src/main/java/wanted/ribbon/genrestrt/config/DataPipeJobConfig.java
+++ b/src/main/java/wanted/ribbon/genrestrt/config/DataPipeJobConfig.java
@@ -3,18 +3,22 @@ package wanted.ribbon.genrestrt.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.PlatformTransactionManager;
 import wanted.ribbon.genrestrt.component.DataFetchTasklet;
 import wanted.ribbon.genrestrt.component.DataPipeTasklet;
 
 @RequiredArgsConstructor
 @Configuration
+@EnableBatchProcessing
+@EnableScheduling
 public class DataPipeJobConfig {
 
     private final JobRepository jobRepository;

--- a/src/main/java/wanted/ribbon/genrestrt/dto/RawData.java
+++ b/src/main/java/wanted/ribbon/genrestrt/dto/RawData.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class RawData {
     private String sigunNm;
     private String bizplcNm;
+    private String bsnStateNm; // data fetch 작업을 위한 영업 상태 데이터
     private String sanittnBizcondNm;
     private String refineRoadnmAddr;
     private Double refineWgs84Lat;

--- a/src/main/java/wanted/ribbon/genrestrt/mapper/RawDataRowMapper.java
+++ b/src/main/java/wanted/ribbon/genrestrt/mapper/RawDataRowMapper.java
@@ -13,6 +13,7 @@ public class RawDataRowMapper implements RowMapper<RawData> {
         return RawData.builder()
                 .sigunNm(rs.getString("sigun_nm"))
                 .bizplcNm(rs.getString("bizplc_nm"))
+                .bsnStateNm(rs.getString("bsn_state_nm")) // 영업상태 추가
                 .sanittnBizcondNm(rs.getString("sanittn_bizcond_nm"))
                 .refineRoadnmAddr(rs.getString("refine_roadnm_addr"))
                 .refineWgs84Lat(rs.getDouble("refine_wgs84lat"))

--- a/src/main/java/wanted/ribbon/genrestrt/mapper/StoreDataRowMapper.java
+++ b/src/main/java/wanted/ribbon/genrestrt/mapper/StoreDataRowMapper.java
@@ -1,0 +1,24 @@
+package wanted.ribbon.genrestrt.mapper;
+
+import org.springframework.jdbc.core.RowMapper;
+import wanted.ribbon.store.domain.Category;
+import wanted.ribbon.store.domain.Store;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class StoreDataRowMapper implements RowMapper<Store> {
+
+    @Override
+    public Store mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return Store.builder()
+                .sigun(rs.getString("sigun"))
+                .storeName(rs.getString("store_name"))
+                .category(Category.valueOf(rs.getString("category")))
+                .address(rs.getString("address"))
+                .storeLat(rs.getDouble("store_lat"))
+                .storeLon(rs.getDouble("store_lon"))
+                .rating(rs.getDouble("rating"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue
- #12 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/data_auto-> dev

## 변경 사항
- `스케줄러`를 설정하여 위 로직을 지정한 시간마다 실행시킵니다.
- `스케줄러` 설정
  - 사용자에게 원활한 서비스를 제공하기 위해 서버가 여유로울 때 진행
  - 이후 이어서 운영데이터 업데이트 매주 월요일 새벽 3시
  - 데이터 전처리 과정에서 현재 영업 상태까지 받도록 코드 수정 
- 원본 테이블의 변경 내용 패치 Job Step2 추가 
  - 영업상태가 폐업으로 변경된 경우
    - 운영 테이블에서 데이터 삭제
    - 원본 테이블에서 가공처리 상태 false로 수정
  - 영업 상태가 운영인데, 데이터가 변경된 경우
    - 원본 테이블에서 바뀐 정보를 받아와 영업 테이블에 업데이트 
    
## 테스트 결과

### Schedule : 성공시

```
Job: [SimpleJob: [name=dataPipeJob]] launched with the following parameters: [{}]
Executing step: [dataPipeStep]
데이터 삽입 성공 및 처리 상태 업데이트: wanted.ribbon.store.domain.Store@3917c51d
페이지 처리 완료: {}개 행 처리됨
배치 작업 완료. 총 {}개의 행이 처리되었습니다.
Step: [dataPipeStep] executed in 161ms
Executing step: [dataFetchStep]
삭제된 맛집: 이름={}, 주소={}
정보가 바뀐 맛집의 수는: 0
정보가 지워진 맛집의 수는: 1
Step: [dataFetchStep] executed in 8s644ms
Job: [SimpleJob: [name=dataPipeJob]] completed with the following parameters: [{}] and the following status: [COMPLETED] in 9s639ms
```

### Schedule : 실패시

```
Step: [dataPipeStep] failed with exception: [NullPointerException]
Step: [dataFetchStep] failed with exception: [NullPointerException]
Job: [SimpleJob: [name=dataPipeJob]] failed with status: [FAILED]
```
