### PR TITLE
[feat] 인기 급상승 맛집 조회 기능 구현

### DIFF
--- a/src/main/java/wanted/ribbon/RibbonApplication.java
+++ b/src/main/java/wanted/ribbon/RibbonApplication.java
@@ -3,8 +3,10 @@ package wanted.ribbon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableCaching
+@EnableJpaAuditing
 @SpringBootApplication
 public class RibbonApplication {
 

--- a/src/main/java/wanted/ribbon/global/config/RedisConfig.java
+++ b/src/main/java/wanted/ribbon/global/config/RedisConfig.java
@@ -11,6 +11,8 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Configuration
 public class RedisConfig {
@@ -19,11 +21,20 @@ public class RedisConfig {
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofDays(1)); // 수명 하루
+                .entryTtl(calculateTime()); // 수명 다음날 0시까지
         return RedisCacheManager
                 .RedisCacheManagerBuilder
                 .fromConnectionFactory(factory)
                 .cacheDefaults(cacheConfig)
                 .build();
+    }
+
+    private Duration calculateTime() {
+        LocalDateTime now = LocalDateTime.now();
+        // 다음날 자정
+        LocalDateTime tomorrow = now.plusDays(1).truncatedTo(ChronoUnit.DAYS);
+        // 현재 시간과 다음날 0시 사이의 초 수
+        long secondsUntilTomorrow = Duration.between(now, tomorrow).getSeconds();
+        return Duration.ofSeconds(secondsUntilTomorrow);
     }
 }

--- a/src/main/java/wanted/ribbon/store/controller/StoreController.java
+++ b/src/main/java/wanted/ribbon/store/controller/StoreController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import wanted.ribbon.store.domain.Category;
 import wanted.ribbon.store.dto.PopularStoreListResponseDto;
+import wanted.ribbon.store.dto.RisingPopularStoreListResponseDto;
 import wanted.ribbon.store.dto.StoreDetailResponseDto;
 import wanted.ribbon.store.dto.StoreListResponseDto;
 import wanted.ribbon.store.service.StoreService;
@@ -51,6 +52,12 @@ public class StoreController {
         } else {
             responseDto = storeService.popularStores();
         }
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @GetMapping("/rising")
+    public ResponseEntity<RisingPopularStoreListResponseDto> getRisingPopularStoreList() {
+        RisingPopularStoreListResponseDto responseDto = storeService.findRisingStores();
         return ResponseEntity.ok().body(responseDto);
     }
 }

--- a/src/main/java/wanted/ribbon/store/domain/Review.java
+++ b/src/main/java/wanted/ribbon/store/domain/Review.java
@@ -2,7 +2,11 @@ package wanted.ribbon.store.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import wanted.ribbon.user.domain.User;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -10,6 +14,7 @@ import wanted.ribbon.user.domain.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Review {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +26,10 @@ public class Review {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)

--- a/src/main/java/wanted/ribbon/store/domain/Store.java
+++ b/src/main/java/wanted/ribbon/store/domain/Store.java
@@ -47,4 +47,8 @@ public class Store {
     public void updateRating(double rating) {
         this.rating = rating;
     }
+
+    public void addReviewCount() {
+        this.reviewCount++;
+    }
 }

--- a/src/main/java/wanted/ribbon/store/dto/RisingPopularStoreListResponseDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/RisingPopularStoreListResponseDto.java
@@ -1,0 +1,16 @@
+package wanted.ribbon.store.dto;
+
+import wanted.ribbon.store.domain.Store;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public record RisingPopularStoreListResponseDto(List<RisingStoreResponseDto> stores) {
+    public static RisingPopularStoreListResponseDto fromRisingStoreList(List<Store> storeList) {
+        List<RisingStoreResponseDto> responseDto = IntStream.range(0, storeList.size())
+                .mapToObj(i -> RisingStoreResponseDto.from(storeList.get(i), i+1))
+                .collect(Collectors.toList());
+        return new RisingPopularStoreListResponseDto(responseDto);
+    }
+}

--- a/src/main/java/wanted/ribbon/store/dto/RisingStoreResponseDto.java
+++ b/src/main/java/wanted/ribbon/store/dto/RisingStoreResponseDto.java
@@ -1,0 +1,23 @@
+package wanted.ribbon.store.dto;
+
+import wanted.ribbon.store.domain.Category;
+import wanted.ribbon.store.domain.Store;
+
+public record RisingStoreResponseDto(Long storeId, String sigun, String storeName,
+                                     Category category, String address,
+                                     double storeLat, double storeLon, double rating,
+                                     int rank) {
+    public static RisingStoreResponseDto from(Store store, int rank) {
+        return new RisingStoreResponseDto(
+                store.getStoreId(),
+                store.getSigun(),
+                store.getStoreName(),
+                store.getCategory(),
+                store.getAddress(),
+                store.getStoreLat(),
+                store.getStoreLon(),
+                store.getRating(),
+                rank
+        );
+    }
+}

--- a/src/main/java/wanted/ribbon/store/repository/ReviewRepository.java
+++ b/src/main/java/wanted/ribbon/store/repository/ReviewRepository.java
@@ -1,12 +1,21 @@
 package wanted.ribbon.store.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import wanted.ribbon.store.domain.Review;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r WHERE r.store.storeId = :storeId ORDER BY r.reviewId DESC")
     List<Review> findByStore_StoreId(Long storeId);
+
+    @Query("SELECT r.store, COUNT(r) as reviewCount FROM Review r " +
+            "WHERE r.createdAt >= :startDate AND r.createdAt < :endDate " +
+            "GROUP BY r.store " +
+            "ORDER BY COUNT(r) DESC")
+    List<Object[]> findStoresByReviewCount(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Pageable pageable);
 }

--- a/src/main/java/wanted/ribbon/store/service/ReviewService.java
+++ b/src/main/java/wanted/ribbon/store/service/ReviewService.java
@@ -41,6 +41,8 @@ public class ReviewService {
 
         // 점수 입력되면 해당 맛집의 평점 update
         updateRating(store);
+        // 해당 맛집의 리뷰 개수 추가
+        store.addReviewCount();
 
         CreateReviewResponseDto responseDto = new CreateReviewResponseDto(id, requestDto.score(), requestDto.content());
         return responseDto;

--- a/src/main/java/wanted/ribbon/store/service/StoreService.java
+++ b/src/main/java/wanted/ribbon/store/service/StoreService.java
@@ -15,6 +15,8 @@ import wanted.ribbon.store.dto.*;
 import wanted.ribbon.store.repository.ReviewRepository;
 import wanted.ribbon.store.repository.StoreRepository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,5 +90,20 @@ public class StoreService {
         Pageable pageable = PageRequest.of(0, 100);
         List<Store> storeList = storeRepository.findPopularStoresBySigun(4.5, 100, sigun, pageable);
         return PopularStoreListResponseDto.fromStoreList(storeList);
+    }
+
+    @Transactional
+    @Cacheable(value = "risingpopularstores", key = "'rising'", cacheManager = "cacheManager")
+    public RisingPopularStoreListResponseDto findRisingStores() {
+        Pageable pageable = PageRequest.of(0, 10);
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDateTime startDate = yesterday.atStartOfDay();
+        LocalDateTime endDate = LocalDate.now().atStartOfDay();
+        List<Object[]> storeList = reviewRepository.findStoresByReviewCount(startDate, endDate, pageable);
+        // Object[]를 Store로 변환
+        List<Store> risingStoreList = storeList.stream()
+                .map(result -> (Store) result[0])
+                .collect(Collectors.toList());
+        return RisingPopularStoreListResponseDto.fromRisingStoreList(risingStoreList);
     }
 }


### PR DESCRIPTION
## Issue
- #35

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat/rising_popular_store -> dev2

## 변경 사항
- redis cache의 만료기간을 하루에서 다음날 자정까지로 변경
- 인기 급상승 맛집 기준은 전날 생성된 리뷰 개수
- review 엔티티에 작성일자 필드 추가
- 10개의 목록 조회

## 테스트 결과

### Request
```java
HTTP : GET
URL: /api/stores/rising
```

### Response : 성공시
```
{
    "stores": [
        {
            "storeId": 1,
            "sigun": "가평군",
            "storeName": "한솥도시락가평점",
            "category": "Lunch",
            "address": "경기도 가평군 가평읍 가화로 88-1, 1층",
            "storeLat": 37.8276878786,
            "storeLon": 127.5147837255,
            "rating": 5.0,
            "rank": 1
        }
    ]
}
```
