### PR TITLE
[fix] genrestrts 테이블의 경도(lon)와 위도(lat) 데이터가 반대로 저장된 문제 해결

### DIFF
--- a/src/main/java/wanted/ribbon/datapipe/component/DataPipeTasklet.java
+++ b/src/main/java/wanted/ribbon/datapipe/component/DataPipeTasklet.java
@@ -63,16 +63,17 @@ public class DataPipeTasklet implements Tasklet {
                 }
 
                 // Store 객체의 정보를 데이터베이스에 삽입
-                jdbcTemplate.update("INSERT INTO stores (sigun, store_name, category, address, store_lat, store_lon, location, rating, review_count) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 4326), ?, ?)",
+                jdbcTemplate.update("INSERT INTO stores (sigun, store_name, category, address, store_lon, store_lat, location, rating, review_count) " +
+                                "VALUES (?, ?, ?, ?, ?, ?, ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 4326), ?, ?)",
                         store.getSigun(),
                         store.getStoreName(),
                         store.getCategory().name(), // enum 값 문자열로 변환
                         store.getAddress(),
-                        store.getStoreLat(),
-                        store.getStoreLon(),
-                        store.getStoreLon(),  // POINT(lon lat) -> 경도(lon), 위도(lat)
-                        store.getStoreLat(),
+                        store.getStoreLon(), // 경도
+                        store.getStoreLat(), // 위도
+                        // POINT(lon lat)이 맞는데 ST_GeomFromText 함수로 넣는 POINT 에서는 반대로해야 db에 올바르게 들어갔음
+                        store.getStoreLat(),  // 여기에서 위도 값을 전달
+                        store.getStoreLon(),  // 여기에서 경도 값을 전달
                         0.0,
                         0); // 평점은 0.0, 리뷰수는 0 디폴트값 입력
 

--- a/src/main/java/wanted/ribbon/datapipe/dto/GyeongGiList.java
+++ b/src/main/java/wanted/ribbon/datapipe/dto/GyeongGiList.java
@@ -9,6 +9,7 @@ public record GyeongGiList(String message,
                            int updatedCount,
                            int unchangedCount,
                            List<GyeongGiApiResponse> gyeongGiApiResponses) {
+
     public record GyeongGiApiResponse(String sigunNm,
                                       String sigunCd,
                                       String bizplcNm,
@@ -30,6 +31,8 @@ public record GyeongGiList(String message,
                                       String refineRoadnmAddr,
                                       String refineLotnoAddr,
                                       String refineZipCd,
-                                      Double refineWgs84Lat,
-                                      Double refineWgs84Logt){}
+                                      Double refineWgs84Logt,
+                                      Double refineWgs84Lat
+    ) {
+    }
 }

--- a/src/main/java/wanted/ribbon/store/controller/StoreController.java
+++ b/src/main/java/wanted/ribbon/store/controller/StoreController.java
@@ -22,11 +22,11 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping
-    public ResponseEntity<StoreListResponseDto> getStoreList(@RequestParam(value = "lat") double lat,
-                                                             @RequestParam(value = "lon") double lon,
+    public ResponseEntity<StoreListResponseDto> getStoreList(@RequestParam(value = "lon") double lon,
+                                                             @RequestParam(value = "lat") double lat,
                                                              @RequestParam(value = "range") double range,
                                                              @RequestParam(value = "orderBy", defaultValue = "distance", required = false) String orderBy) {
-        StoreListResponseDto storeList = storeService.findStores(lat, lon, range, orderBy);
+        StoreListResponseDto storeList = storeService.findStores(lon, lat, range, orderBy);
         if (storeList.isEmpty())
             return ResponseEntity.noContent().build();
         return ResponseEntity.ok().body(storeList);
@@ -45,9 +45,9 @@ public class StoreController {
             @Parameter(description = "조회할 카테고리") @RequestParam(required = false) Category category,
             @Parameter(description = "조회할 지역") @RequestParam(required = false) String sigun) {
         PopularStoreListResponseDto responseDto;
-        if(category != null) {
+        if (category != null) {
             responseDto = storeService.findPopularCategoryStores(category);
-        } else if(sigun != null) {
+        } else if (sigun != null) {
             responseDto = storeService.findPopularSigunStores(sigun);
         } else {
             responseDto = storeService.popularStores();

--- a/src/main/java/wanted/ribbon/store/domain/Store.java
+++ b/src/main/java/wanted/ribbon/store/domain/Store.java
@@ -35,10 +35,10 @@ public class Store {
     private String address;
 
     @Column(nullable = false)
-    private double storeLon; // 경도 (세로)
+    private double storeLon; // 경도 (세로선=동서)
 
     @Column(nullable = false)
-    private double storeLat; // 위도 (가로)
+    private double storeLat; // 위도 (가로선=남북)
 
     @Column(nullable = false, columnDefinition = "POINT SRID 4326")
     private Point location; // Point(경도, 위도)
@@ -60,7 +60,7 @@ public class Store {
     // GeometryFactory는 thread-safe, stateless 하므로, static으로 선언하여 성능 개선
     private static final GeometryFactory geometryFactory = new GeometryFactory();
 
-    // storeLat, storeLon으로 location(Point) 설정
+    // storeLon, storeLat으로 location(Point) 설정
     public void setLocation(double storeLon, double storeLat) {
         this.location = geometryFactory.createPoint(new Coordinate(storeLon, storeLat));
         this.location.setSRID(4326);
@@ -76,7 +76,7 @@ public class Store {
         ensureLocation();
     }
 
-    // @PreUpdate: 엔티티가 업데이트될 때 (위도/경도 값이 변경되면) 자동으로 location 필드 갱신
+    // @PreUpdate: 엔티티가 업데이트될 때 (경도/위도 값이 변경되면) 자동으로 location 필드 갱신
     @PreUpdate
     public void preUpdate() {
         ensureLocation();

--- a/src/main/java/wanted/ribbon/store/service/StoreService.java
+++ b/src/main/java/wanted/ribbon/store/service/StoreService.java
@@ -53,26 +53,26 @@ public class StoreService {
     }
 
     /**
-     * 위도, 경도에서 첫 번째 소수점 자리는 최대 11.1km, 두 번째 소수점 자리는 1.1 km, 세 번째 소수점 자리는 110m 이다.
-     * 여섯 번째 자리는 11cm를 나타내기에 보통 위도, 경도를 소수 6자리까지 나타내고, 계산해도 큰 오차가 없다.
+     * 경도, 위도에서 첫 번째 소수점 자리는 최대 11.1km, 두 번째 소수점 자리는 1.1 km, 세 번째 소수점 자리는 110m 이다.
+     * 여섯 번째 자리는 11cm를 나타내기에 보통 경도, 위도를 소수 6자리까지 나타내고, 계산해도 큰 오차가 없다.
      *
-     * @param lat     위도 (가로)
-     * @param lon     경도 (세로)
-     * @param range   위도, 경도로 지정한 위치 주변의 검색할 범위 설정 값 (단위는 km이며, range 1.0은 1km이다.)
+     * @param lat     위도 (가로선=남북) (위도 범위 : -90 ~ 90)
+     * @param lon     경도 (세로선=동서) (경도 범위 : -180 ~ 180)
+     * @param range   경도, 위도로 지정한 위치 주변의 검색할 범위 값 (단위는 km 이며, range 1.0은 1km 이다.)
      * @param orderBy store 데이터 정렬 기준 (거리순과 평점순 2가지)
      */
     public StoreListResponseDto findStores(double lat, double lon, double range, String orderBy) {
-        // 위도, 경도의 계산을 위해 km를 m로 변환
+        // 경도, 위도의 계산을 위해 km를 m로 변환
         double meterRange = range * 1000;
         // bbox를 구하는 4 모서리 좌표 계산에 활용하기 위해 반으로 나눔
         double moveRange = meterRange / 2;
-        // 위도, 경도에서 0.01도는 1100m인 것을 사용해 몇 m는 위도, 경도로 어느 정도인지 계산
+        // 경도, 위도에서 0.01도는 1100m인 것을 사용해 몇 m는 위도, 경도로 어느 정도인지 계산
         double meterToDegree = moveRange * 0.01 / 1100; // 0.01 : 1100 = meterToDegree : moveRange(몇 m)
         // 1. 기존 방식 - QueryDsl을 사용한 방법
 //        List<Store> storeList = storeRepository.findAllStores(lat, lon, meterToDegree, meterRange, orderBy);
 
         // 2. 리팩토링 방식 - 공간 함수를 사용한 JPQL 쿼리 방법
-        // 사용자의 위도, 경도를 Point 데이터 타입으로 변경
+        // 사용자의 경도, 위도를 Point 데이터 타입으로 변경
         Point userLocation = geometryFactory.createPoint(new Coordinate(lon, lat));
         userLocation.setSRID(4326); // SRID 4326 (WGS 84 좌표계)로 설정
 

--- a/src/main/java/wanted/ribbon/store/service/StoreService.java
+++ b/src/main/java/wanted/ribbon/store/service/StoreService.java
@@ -56,12 +56,12 @@ public class StoreService {
      * 경도, 위도에서 첫 번째 소수점 자리는 최대 11.1km, 두 번째 소수점 자리는 1.1 km, 세 번째 소수점 자리는 110m 이다.
      * 여섯 번째 자리는 11cm를 나타내기에 보통 경도, 위도를 소수 6자리까지 나타내고, 계산해도 큰 오차가 없다.
      *
-     * @param lat     위도 (가로선=남북) (위도 범위 : -90 ~ 90)
      * @param lon     경도 (세로선=동서) (경도 범위 : -180 ~ 180)
+     * @param lat     위도 (가로선=남북) (위도 범위 : -90 ~ 90)
      * @param range   경도, 위도로 지정한 위치 주변의 검색할 범위 값 (단위는 km 이며, range 1.0은 1km 이다.)
      * @param orderBy store 데이터 정렬 기준 (거리순과 평점순 2가지)
      */
-    public StoreListResponseDto findStores(double lat, double lon, double range, String orderBy) {
+    public StoreListResponseDto findStores(double lon, double lat, double range, String orderBy) {
         // 경도, 위도의 계산을 위해 km를 m로 변환
         double meterRange = range * 1000;
         // bbox를 구하는 4 모서리 좌표 계산에 활용하기 위해 반으로 나눔


### PR DESCRIPTION
## Issue
- #45 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
fix/genrestrts_table_lon_lat_swap → dev2

## 변경 사항
- OpenAPI를 통한 경기도 맛집 데이터 파싱 시 반대로 되어있던 경도(lon)와 위도(lat) 값을 교환(swap)해서 문제 해결
- stores 테이블의 경도(lon)와 위도(lat)가 반대로 저장된 문제 해결

## 테스트 결과
- genrestrts 테이블
  ![image](https://github.com/user-attachments/assets/b64d0de3-1491-4582-88ef-c951306886d6)
- stores 테이블
  ![image](https://github.com/user-attachments/assets/d41fd5e5-b07e-4cf6-9bb6-a5742be7b982)
